### PR TITLE
Replace active class with is-active class

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage
   <li class="step-item">
     <a href="#steps"></a>
   </li>
-  <li class="step-item active">
+  <li class="step-item is-active">
     <a href="#steps"></a>
   </li>
   <li class="step-item">
@@ -31,7 +31,7 @@ Usage
   <li class="step-item">
     <a href="#steps">Step 2</a>
   </li>
-  <li class="step-item active">
+  <li class="step-item is-active">
     <a href="#steps">Step 3</a>
   </li>
   <li class="step-item">

--- a/steps.sass
+++ b/steps.sass
@@ -44,12 +44,12 @@
         transform: translateX(-50%)
         width: 1.2rem
         z-index: 1
-    &.active
+    &.is-active
       a
         &::before
           background: #fff
           border: .2rem solid $primary
-    &.active ~ .step-item::before
+    &.is-active ~ .step-item::before
         background: #f0f1f4
-    &.active ~ .step-item a::before
+    &.is-active ~ .step-item a::before
         background: #e7e9ed


### PR DESCRIPTION
Replace `active` class with `is-active` class to maintain syntax consistency with Bulma's use of `is-{modifier}` as a modifier.

Example: [Bulma: Modifiers Syntax](http://bulma.io/documentation/modifiers/syntax/)