### PR TITLE
Jump straight into a given step

### DIFF
--- a/src/js/defaultOptions.js
+++ b/src/js/defaultOptions.js
@@ -9,7 +9,8 @@ const defaultOptions = {
     'beforeNext': null,
     'onShow': null,
     'onFinish': null,
-    'onError': null
+    'onError': null,
+    'step_idx': 0,
 };
 
 export default defaultOptions;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -63,9 +63,16 @@ export default class bulmaSteps extends EventEmitter {
       step.setAttribute('data-step-id', index);
     });
 
+    if (this.options.step_idx < 0 || this.options.step_idx > this.steps.length) {
+      this.options.step_idx = 0
+    }
+
     if (this.steps && this.steps.length) {
-      this.activate_step(0);
-      this.updateActions(this.steps[0]);
+      for (var i = 0; i < this.options.step_idx ; i++) {
+        this.complete_step(i);
+      }
+      this.activate_step(this.options.step_idx);
+      this.updateActions(this.steps[this.options.step_idx]);
     }
 
     this._bindEvents();


### PR DESCRIPTION
This feature sets the initial view to a given step.
ex: `bulmaSteps.attach('.steps', {'step_idx': 2});`